### PR TITLE
Feature/update 1.2.4

### DIFF
--- a/docs/eslint-custom-rules.md
+++ b/docs/eslint-custom-rules.md
@@ -12,6 +12,8 @@ tests.
 - [Verify TODOs Have Links](#verify-todos-have-links)
 - [Verify Test Title Without Forbidden Symbols](#verify-test-title-without-forbidden-symbols)
 - [Standardize Test Titles](#standardize-test-titles)
+- [API Command Naming Rule](#api-command-naming-rule)
+- [UI Command Naming Rule](#ui-command-naming-rule)
 
 ## Do Not Allow Empty Blocks
 
@@ -134,3 +136,68 @@ terms. This improves clarity and uniformity across the test suite.
 The rule scans the titles of `describe`, `context`, and `it` blocks and automatically suggests replacements for
 non-standard terms (e.g., replacing `show` with `display`, `btn` with `button`, `is shown` with `is displayed`, etc.).
 
+
+## API Command Naming Rule
+
+### Rule: `verify-api-command-naming`
+
+**Location:** `eslint-plugin-custom-rules/verify-api-command-naming.js`
+
+**Applies to:** Files in `cypress/support/commands/api/` ending with `.api.commands.js`
+
+### Pattern
+```
+resourceName__actionDescription__METHOD
+```
+
+### Requirements
+1. **Three parts separated by double underscores (`__`)**
+    - Resource name (e.g., `settingAuditRound`, `templates`, `questions`)
+    - Action description (e.g., `add`, `getById`, `update`, `delete`)
+    - HTTP method (e.g., `GET`, `POST`, `PUT`, `PATCH`, `DELETE`)
+
+2. **Resource name**
+    - Must start with lowercase letter
+    - Can contain letters, numbers, and underscores
+    - Use camelCase
+    - Examples: `settingAuditRound`, `settingActionPriority`, `templates`, `audits`
+
+3. **Action description**
+    - Must start with lowercase letter
+    - Can contain letters and numbers only
+    - Use camelCase
+    - Examples: `add`, `getById`, `update`, `delete`, `getAll`, `addComment`
+
+4. **HTTP method**
+    - Must be uppercase
+    - Valid methods: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`
+
+## UI Command Naming Rule
+
+### Rule: `verify-ui-command-naming`
+
+**Location:** `eslint-plugin-custom-rules/verify-ui-command-naming.js`
+
+**Applies to:** Files in `cypress/support/commands/ui/` ending with `.ui.commands.js`
+
+### Pattern
+```
+pageName__actionDescription
+```
+
+### Requirements
+1. **Two parts separated by double underscores (`__`)**
+    - Page/component name (e.g., `loginPage`, `checkoutPage`, `auditPerformPage`)
+    - Action description (e.g., `logIn`, `fillForm`, `submitData`)
+
+2. **Page name**
+    - Must start with lowercase letter
+    - Can contain letters and numbers only
+    - Use camelCase
+    - Examples: `loginPage`, `checkoutPage`, `auditPerformPage`, `templatesPage`
+
+3. **Action description**
+    - Must start with lowercase letter
+    - Can contain letters and numbers only
+    - Use camelCase
+    - Examples: `logIn`, `fillForm`, `submitData`, `clickButton`, `selectOption`

--- a/docs/eslint-custom-rules.md
+++ b/docs/eslint-custom-rules.md
@@ -152,7 +152,7 @@ resourceName__actionDescription__METHOD
 
 ### Requirements
 1. **Three parts separated by double underscores (`__`)**
-    - Resource name (e.g., `settingAuditRound`, `templates`, `questions`)
+    - Resource name (e.g., `restfullBooker`, `templates`)
     - Action description (e.g., `add`, `getById`, `update`, `delete`)
     - HTTP method (e.g., `GET`, `POST`, `PUT`, `PATCH`, `DELETE`)
 
@@ -160,7 +160,7 @@ resourceName__actionDescription__METHOD
     - Must start with lowercase letter
     - Can contain letters, numbers, and underscores
     - Use camelCase
-    - Examples: `settingAuditRound`, `settingActionPriority`, `templates`, `audits`
+    - Examples: `restfullBooker`, `templates`
 
 3. **Action description**
     - Must start with lowercase letter
@@ -187,17 +187,17 @@ pageName__actionDescription
 
 ### Requirements
 1. **Two parts separated by double underscores (`__`)**
-    - Page/component name (e.g., `loginPage`, `checkoutPage`, `auditPerformPage`)
+    - Page/component name (e.g., `loginPage`, `checkoutPage`)
     - Action description (e.g., `logIn`, `fillForm`, `submitData`)
 
 2. **Page name**
     - Must start with lowercase letter
     - Can contain letters and numbers only
     - Use camelCase
-    - Examples: `loginPage`, `checkoutPage`, `auditPerformPage`, `templatesPage`
+    - Examples: `loginPage`, `checkoutPage`
 
 3. **Action description**
     - Must start with lowercase letter
     - Can contain letters and numbers only
     - Use camelCase
-    - Examples: `logIn`, `fillForm`, `submitData`, `clickButton`, `selectOption`
+    - Examples: `logIn`, `fillForm`, `submitData`, `clickButton`

--- a/eslint-plugin-custom-rules/index.js
+++ b/eslint-plugin-custom-rules/index.js
@@ -7,5 +7,7 @@ module.exports = {
     'verify-todos-have-links': require('./verify-todos-have-links.js'),
     'verify-test-title-without-forbidden-symbols': require('./verify-test-title-without-forbidden-symbols.js'),
     'standardize-test-titles': require('./standardize-test-titles.js'),
+    'verify-api-command-naming': require('./verify-api-command-naming.js'),
+    'verify-ui-command-naming': require('./verify-ui-command-naming.js'),
   },
 };

--- a/eslint-plugin-custom-rules/verify-api-command-naming.js
+++ b/eslint-plugin-custom-rules/verify-api-command-naming.js
@@ -29,7 +29,6 @@ module.exports = {
     // - resourceName: camelCase (may include underscores for nested resources like setting_auditRound)
     // - actionDescription: camelCase
     // - METHOD: uppercase HTTP method
-    const apiCommandPattern = /^[a-z][a-zA-Z0-9_]*__[a-z][a-zA-Z0-9]*__[A-Z]+$/;
 
     function validateApiCommandName(commandName) {
       // Check for double underscores
@@ -60,11 +59,6 @@ module.exports = {
       // Validate action name (must start with lowercase letter, can contain letters and numbers)
       if (!/^[a-z][a-zA-Z0-9]*$/.test(action)) {
         return 'invalidCasing';
-      }
-
-      // Check overall pattern
-      if (!apiCommandPattern.test(commandName)) {
-        return 'invalidApiCommandName';
       }
 
       return null;

--- a/eslint-plugin-custom-rules/verify-api-command-naming.js
+++ b/eslint-plugin-custom-rules/verify-api-command-naming.js
@@ -72,12 +72,6 @@ module.exports = {
         if (commandNameNode && commandNameNode.type === 'Literal') {
           const commandName = commandNameNode.value;
 
-          // Skip utility commands that don't follow the pattern
-          const utilityCommands = ['getTokenByRole', 'clearSessionCookies', 'getAllLanguages'];
-          if (utilityCommands.includes(commandName)) {
-            return;
-          }
-
           const error = validateApiCommandName(commandName);
 
           if (error) {

--- a/eslint-plugin-custom-rules/verify-api-command-naming.js
+++ b/eslint-plugin-custom-rules/verify-api-command-naming.js
@@ -1,0 +1,102 @@
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Verify API command names follow the naming convention: resourceName__actionDescription__METHOD',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      invalidApiCommandName: 'API command name "{{commandName}}" does not follow the naming convention. Expected pattern: resourceName__actionDescription__METHOD (e.g., "settingAuditRound__add__POST", "templates__getById__GET")',
+      missingDoubleUnderscore: 'API command name "{{commandName}}" must use double underscores (__) as separators',
+      invalidHttpMethod: 'API command name "{{commandName}}" must end with a valid HTTP method: GET, POST, PUT, PATCH, DELETE',
+      invalidCasing: 'API command name "{{commandName}}" must use camelCase for resource and action parts',
+    },
+  },
+  create(context) {
+    const filename = context.getFilename();
+
+    // Only apply this rule to API command files
+    if (!filename.includes('/commands/api/') || !filename.endsWith('.api.commands.js')) {
+      return {};
+    }
+
+    // Valid HTTP methods
+    const validMethods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'];
+
+    // Pattern: resourceName__actionDescription__METHOD
+    // - resourceName: camelCase (may include underscores for nested resources like setting_auditRound)
+    // - actionDescription: camelCase
+    // - METHOD: uppercase HTTP method
+    const apiCommandPattern = /^[a-z][a-zA-Z0-9_]*__[a-z][a-zA-Z0-9]*__[A-Z]+$/;
+
+    function validateApiCommandName(commandName) {
+      // Check for double underscores
+      if (!commandName.includes('__')) {
+        return 'missingDoubleUnderscore';
+      }
+
+      // Split by double underscores
+      const parts = commandName.split('__');
+
+      // Must have exactly 3 parts: resource, action, method
+      if (parts.length !== 3) {
+        return 'invalidApiCommandName';
+      }
+
+      const [resource, action, method] = parts;
+
+      // Validate HTTP method
+      if (!validMethods.includes(method)) {
+        return 'invalidHttpMethod';
+      }
+
+      // Validate resource name (must start with lowercase letter, can contain letters, numbers, underscores)
+      if (!/^[a-z][a-zA-Z0-9_]*$/.test(resource)) {
+        return 'invalidCasing';
+      }
+
+      // Validate action name (must start with lowercase letter, can contain letters and numbers)
+      if (!/^[a-z][a-zA-Z0-9]*$/.test(action)) {
+        return 'invalidCasing';
+      }
+
+      // Check overall pattern
+      if (!apiCommandPattern.test(commandName)) {
+        return 'invalidApiCommandName';
+      }
+
+      return null;
+    }
+
+    return {
+      // Match Cypress.Commands.add('commandName', ...)
+      'CallExpression[callee.object.object.name="Cypress"][callee.object.property.name="Commands"][callee.property.name="add"]'(node) {
+        const commandNameNode = node.arguments[0];
+
+        if (commandNameNode && commandNameNode.type === 'Literal') {
+          const commandName = commandNameNode.value;
+
+          // Skip utility commands that don't follow the pattern
+          const utilityCommands = ['getTokenByRole', 'clearSessionCookies', 'getAllLanguages'];
+          if (utilityCommands.includes(commandName)) {
+            return;
+          }
+
+          const error = validateApiCommandName(commandName);
+
+          if (error) {
+            context.report({
+              node: commandNameNode,
+              messageId: error,
+              data: {
+                commandName,
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/eslint-plugin-custom-rules/verify-ui-command-naming.js
+++ b/eslint-plugin-custom-rules/verify-ui-command-naming.js
@@ -1,0 +1,87 @@
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Verify UI command names follow the naming convention: pageName__actionDescription',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      invalidUiCommandName: 'UI command name "{{commandName}}" does not follow the naming convention. Expected pattern: pageName__actionDescription (e.g., "loginPage__logIn", "checkoutPage__fillForm")',
+      missingDoubleUnderscore: 'UI command name "{{commandName}}" must use double underscores (__) as separator',
+      invalidCasing: 'UI command name "{{commandName}}" must use camelCase for page and action parts',
+      tooManyParts: 'UI command name "{{commandName}}" must have exactly two parts: pageName__actionDescription',
+    },
+  },
+  create(context) {
+    const filename = context.getFilename();
+
+    // Only apply this rule to UI command files
+    if (!filename.includes('/commands/ui/') || !filename.endsWith('.ui.commands.js')) {
+      return {};
+    }
+
+    // Pattern: pageName__actionDescription
+    // - pageName: camelCase
+    // - actionDescription: camelCase
+    const uiCommandPattern = /^[a-z][a-zA-Z0-9]*__[a-z][a-zA-Z0-9]*$/;
+
+    function validateUiCommandName(commandName) {
+      // Check for double underscores
+      if (!commandName.includes('__')) {
+        return 'missingDoubleUnderscore';
+      }
+
+      // Split by double underscores
+      const parts = commandName.split('__');
+
+      // Must have exactly 2 parts: page, action
+      if (parts.length !== 2) {
+        return 'tooManyParts';
+      }
+
+      const [page, action] = parts;
+
+      // Validate page name (must start with lowercase letter, can contain letters and numbers)
+      if (!/^[a-z][a-zA-Z0-9]*$/.test(page)) {
+        return 'invalidCasing';
+      }
+
+      // Validate action name (must start with lowercase letter, can contain letters and numbers)
+      if (!/^[a-z][a-zA-Z0-9]*$/.test(action)) {
+        return 'invalidCasing';
+      }
+
+      // Check overall pattern
+      if (!uiCommandPattern.test(commandName)) {
+        return 'invalidUiCommandName';
+      }
+
+      return null;
+    }
+
+    return {
+      // Match Cypress.Commands.add('commandName', ...)
+      'CallExpression[callee.object.object.name="Cypress"][callee.object.property.name="Commands"][callee.property.name="add"]'(node) {
+        const commandNameNode = node.arguments[0];
+
+        if (commandNameNode && commandNameNode.type === 'Literal') {
+          const commandName = commandNameNode.value;
+
+          const error = validateUiCommandName(commandName);
+
+          if (error) {
+            context.report({
+              node: commandNameNode,
+              messageId: error,
+              data: {
+                commandName,
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/eslint-plugin-custom-rules/verify-ui-command-naming.js
+++ b/eslint-plugin-custom-rules/verify-ui-command-naming.js
@@ -25,7 +25,6 @@ module.exports = {
     // Pattern: pageName__actionDescription
     // - pageName: camelCase
     // - actionDescription: camelCase
-    const uiCommandPattern = /^[a-z][a-zA-Z0-9]*__[a-z][a-zA-Z0-9]*$/;
 
     function validateUiCommandName(commandName) {
       // Check for double underscores
@@ -51,11 +50,6 @@ module.exports = {
       // Validate action name (must start with lowercase letter, can contain letters and numbers)
       if (!/^[a-z][a-zA-Z0-9]*$/.test(action)) {
         return 'invalidCasing';
-      }
-
-      // Check overall pattern
-      if (!uiCommandPattern.test(commandName)) {
-        return 'invalidUiCommandName';
       }
 
       return null;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -34,6 +34,8 @@ export default [
       'custom/verify-test-title-without-forbidden-symbols': 'error',
       'custom/standardize-test-titles': 'warn',
       'custom/verify-todos-have-links': 'error',
+      'custom/verify-api-command-naming': 'error',
+      'custom/verify-ui-command-naming': 'error',
     },
   },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "eslint-plugin-cypress": "^5.2.0",
         "eslint-plugin-prettier": "^5.5.4",
         "husky": "^9.1.7",
-        "prettier": "^3.6.2"
+        "prettier": "^3.7.1"
       },
       "engines": {
         "node": ">=24.0.0"
@@ -3012,9 +3012,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.1.tgz",
+      "integrity": "sha512-RWKXE4qB3u5Z6yz7omJkjWwmTfLdcbv44jUVHC5NpfXwFGzvpQM798FGv/6WNK879tc+Cn0AAyherCl1KjbyZQ==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -376,17 +376,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@pkgr/core": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,12 @@
       "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
-        "cypress": "^15.6.0",
+        "cypress": "^15.7.0",
         "mochawesome": "^7.1.4"
+      },
+      "bin": {
+        "create-cypress-start": "bin/cypress-start.js",
+        "cypress-start": "bin/cypress-start.js"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -1026,9 +1030,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.6.0.tgz",
-      "integrity": "sha512-Vqo66GG1vpxZ7H1oDX9umfmzA3nF7Wy80QAc3VjwPREO5zTY4d1xfQFNPpOWleQl9vpdmR2z1liliOcYlRX6rQ==",
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.7.0.tgz",
+      "integrity": "sha512-1C81zKxnQckYm2XGi37rPV4rN0bzUoWhydhKdOyshJn5gJKszEx5as9VLSZI0jp0ye49QxmnbU4TtMpcD+OmGQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1068,7 +1072,6 @@
         "process": "^0.11.10",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
-        "semver": "^7.7.1",
         "supports-color": "^8.1.1",
         "systeminformation": "5.27.7",
         "tmp": "~0.2.4",
@@ -1877,9 +1880,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -3232,18 +3235,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
-    },
-    "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "husky": "^9.1.7"
   },
   "dependencies": {
-    "cypress": "^15.6.0",
+    "cypress": "^15.7.0",
     "mochawesome": "^7.1.4"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-cypress": "^5.2.0",
     "eslint-plugin-prettier": "^5.5.4",
-    "prettier": "^3.6.2",
+    "prettier": "^3.7.1",
     "husky": "^9.1.7"
   },
   "dependencies": {


### PR DESCRIPTION
This PR adds ESLint custom rules to enforce naming conventions for API and UI Cypress commands, along with a Cypress version update from 15.6.0 to 15.7.0.

Key Changes:

Added two new ESLint rules (verify-api-command-naming and verify-ui-command-naming) to enforce consistent command naming patterns across the test framework
Updated Cypress from version 15.6.0 to 15.7.0
Added comprehensive documentation for the new naming rules