### PR TITLE
Bump version to 2.0.5 in package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cypress-start",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cypress-start",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-start",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Cypress testing framework starter - Professional test automation framework template with comprehensive structure, documentation, and best practices",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR bumps the project’s published version from 2.0.4 → 2.0.5 to keep metadata consistent for npm packaging and releases.

Changes:

Update version in package.json to 2.0.5.
Update the corresponding root package version fields in package-lock.json to 2.0.5.