### PR TITLE
Feature/update 2.0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Create a new project from this template in seconds! The CLI offers three setup m
 ### 🚀 Create New Project with cypress-start CLI (Recommended)
 
 ```bash
-# Using npx (no installation required)
+# Using npx or npm
 npx cypress-start my-project
 
 # Or copy selected modules into the current directory
@@ -57,7 +57,7 @@ latest template, adds/overwrites managed files, deletes files that are no longer
 the diff and roll back individual edits before committing:
 
 ```bash
-# From inside the project
+# From inside the project (or: npm exec --yes --package=cypress-start@latest -- cypress-start ./path/to/project)
 npx cypress-start
 # choose "3. Update Existing Project"
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Create a new project from this template in seconds! The CLI offers three setup m
 npx cypress-start my-project
 
 # Or copy selected modules into the current directory
-npx cypress-start .
+npm exec --yes --package=cypress-start@latest -- cypress-start .
 ```
 
 **Mode 1 — Full Setup** clones the complete framework, initializes a fresh git repo, and runs `npm install`. Best for
@@ -49,7 +49,7 @@ new standalone projects.
 
 **Mode 2 — Specific Files** cherry-picks modules (ESLint, Docs, Claude Skills, Parallel Runner, GitHub Actions, Docker)
 into an existing project directory. `package.json` is created or merged automatically; run `npm install` manually after.
-Use `npx cypress-start .` when you want the selected modules copied into the folder you are already in.
+Use `npm exec --yes --package=cypress-start@latest -- cypress-start .` when you want the selected modules copied into the folder you are already in.
 
 **Mode 3 — Update Existing Project** refreshes a project you already created **in place** — no new subfolder. It pulls the
 latest template, adds/overwrites managed files, deletes files that are no longer part of the template, and merges
@@ -57,7 +57,7 @@ latest template, adds/overwrites managed files, deletes files that are no longer
 the diff and roll back individual edits before committing:
 
 ```bash
-# From inside the project (or: npx cypress-start ./path/to/project)
+# From inside the project
 npx cypress-start
 # choose "3. Update Existing Project"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cypress-start",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cypress-start",
-      "version": "2.0.6",
+      "version": "2.0.7",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-start",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Cypress testing framework starter - Professional test automation framework template with comprehensive structure, documentation, and best practices",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updates the published CLI usage documentation and bumps the package version to 2.0.7, aligning the README with a newer invocation style for running the CLI without installing it globally.

Changes:

Updated README CLI examples to prefer npm exec --yes --package=cypress-start@latest -- cypress-start ... for copying modules into the current directory.
Bumped version from 2.0.6 to 2.0.7 in package.json and package-lock.json.